### PR TITLE
Addressing John's notes

### DIFF
--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,0 +1,6 @@
+{
+    "trailingComma": "none",
+    "tabWidth": 2,
+    "semi": true,
+    "singleQuote": false
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -2832,6 +2832,37 @@
       "resolved": "https://artifactory.lkeymgmt.com/artifactory/api/npm/npm/aws4/-/aws4-1.9.1.tgz",
       "integrity": "sha1-fjPY99RJs/ZzzXLeuavcVS2+Uo4="
     },
+    "axios": {
+      "version": "0.19.2",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.19.2.tgz",
+      "integrity": "sha512-fjgm5MvRHLhx+osE2xoekY70AhARk3a6hkN+3Io1jc00jtquGvxYlKlsFUhmUET0V5te6CcZI7lcv2Ym61mjHA==",
+      "requires": {
+        "follow-redirects": "1.5.10"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "follow-redirects": {
+          "version": "1.5.10",
+          "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.5.10.tgz",
+          "integrity": "sha512-0V5l4Cizzvqt5D44aTXbFZz+FtyXV1vrDN6qrelxtfYQKW0KO0W2T/hkE8xvGa/540LkZlkaUjO4ailYTFtHVQ==",
+          "requires": {
+            "debug": "=3.1.0"
+          }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+        }
+      }
+    },
     "axobject-query": {
       "version": "2.1.2",
       "resolved": "https://artifactory.lkeymgmt.com/artifactory/api/npm/npm/axobject-query/-/axobject-query-2.1.2.tgz",

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "@types/node": "^13.9.1",
     "@types/react": "^16.9.23",
     "@types/react-dom": "^16.9.5",
+    "axios": "^0.19.2",
     "moment": "^2.24.0",
     "react": "^16.13.0",
     "react-bootstrap": "^1.0.0-beta.17",

--- a/src/api/rockets/index.test.ts
+++ b/src/api/rockets/index.test.ts
@@ -106,10 +106,10 @@ describe("getRocketsList()", () => {
     });
     //error message to be retunred by catch
     const error = {
-      errors: { message: "Network error: Something went wrong" }
+      errors: [{ message: "Network error: Something went wrong" }]
     };
     //mock error call
-    mockedAxios.get.mockRejectedValue(error.errors.message);
+    mockedAxios.get.mockRejectedValue(error.errors[0].message);
     const response = await getRocketsList();
     //matches error
     expect(response).toEqual(error);

--- a/src/api/rockets/index.test.ts
+++ b/src/api/rockets/index.test.ts
@@ -1,19 +1,79 @@
-import { getRocketsList, parseUrl } from "./";
+import { getRocketsList, getRockets, parseUrl } from "./";
+import axios from "axios";
+jest.mock("axios");
+const mockedAxios = axios as jest.Mocked<typeof axios>;
 import moment from "moment";
 
-describe("getRocketsList()", () => {
-  it("returns an array of Rockets", async () => {
-    const response = await getRocketsList();
-    if (response.data) {
-      expect(response.data.length).toEqual(4);
-      expect(response.data[0]).toEqual({
-        changed: moment("2017-02-21 00:00:00", "YYYY-MM-DD HH:mm:ss"),
-        configuration: "9 v1.1",
-        id: 1,
-        name: "Falcon 9 v1.1",
-        wikiURL: new URL("http://en.wikipedia.org/wiki/Falcon_9")
-      });
+// describe("getRocketsList()", () => {
+//   it("returns an array of Rockets", async () => {
+//     const response = await getRocketsList();
+//     if (response.data) {
+//       expect(response.data.length).toEqual(30);
+//       expect(response.data[0]).toEqual({
+//         changed: moment("2017-02-21 00:00:00", "YYYY-MM-DD HH:mm:ss"),
+//         configuration: "9 v1.1",
+//         id: 1,
+//         name: "Falcon 9 v1.1",
+//         wikiURL: new URL("http://en.wikipedia.org/wiki/Falcon_9")
+//       });
+//     }
+//   });
+//   it("returns an error message", async () => {
+//     try {
+//       await getRocketsList();
+//     } catch (e) {
+//       expect(e).toMatch("error");
+//     }
+//   });
+// });
+
+//Even though the above test was actually passing the test cases and getting back data from axios
+//we do not want to actually hit the API EVERY time we test.  This would cause additional API calls,
+//and could end up being a costly mistake.  ALso, we want to stay away from testing the actual api calls,
+//for perforance reasons.  Uneccessary HTTP requests are usually public enemy number one when we are looking
+//for ways to optimize our application.
+
+//I will instead mock axios and test the async calls with a mocked version of axios...
+
+const rockets = {
+  rockets: [
+    {
+      id: 1,
+      name: "Falcon 9 v1.1",
+      configuration: "9 v1.1",
+      defaultPads: "84,100",
+      infoURL: null,
+      wikiURL: "http://en.wikipedia.org/wiki/Falcon_9",
+      infoURLs: ["http://www.spacex.com/falcon9"],
+      imageSizes: [320, 480, 640, 720, 768, 800, 960, 1024, 1080, 1280],
+      imageURL:
+        "https://s3.amazonaws.com/launchlibrary/RocketImages/Falcon9v1.1.jpg_1280.jpg",
+      changed: "2017-02-21 00:00:00"
     }
+  ]
+};
+
+describe("getRockets()", () => {
+  beforeEach(() => {
+    mockedAxios.get.mockImplementation(() =>
+      Promise.resolve({
+        data: rockets
+      })
+    );
+  });
+  describe("when an API call is made", () => {
+    it("should render a list of rockets from the API call", async () => {
+      const results = await getRockets();
+      expect(results).toEqual(rockets);
+    });
+    it("function should have been called once", () => {
+      expect(mockedAxios.get).toHaveBeenCalledTimes(1);
+    });
+    it("function should have been called with the correct API endpoint ", () => {
+      expect(mockedAxios.get).toHaveBeenCalledWith(
+        "https://launchlibrary.net/1.4/rocket?mode=list"
+      );
+    });
   });
 });
 

--- a/src/api/rockets/index.test.ts
+++ b/src/api/rockets/index.test.ts
@@ -104,7 +104,6 @@ describe("getRocketsList()", () => {
           "Our apologies, the data has errors, we'll try to request it one more time."
       };
     });
-
     //error message to be retunred by catch
     const error = {
       errors: { message: "Network error: Something went wrong" }

--- a/src/api/rockets/index.test.ts
+++ b/src/api/rockets/index.test.ts
@@ -31,6 +31,7 @@ const rockets = {
   ]
 };
 
+//our transform function return this converted object
 const transformedRocket = {
   id: 1,
   name: "Falcon 9 v1.1",
@@ -151,6 +152,7 @@ describe("TypeScript Interfaces - JsonRocket, JsonResponse", () => {
   });
 });
 
+//testing the transform function with the expected contant "transformedRocket"
 describe("transformRespondRecord", () => {
   it("should return the correct transformed JSON object ", () => {
     const result = transformResponseRecord(rockets.rockets[0]);

--- a/src/api/rockets/index.test.ts
+++ b/src/api/rockets/index.test.ts
@@ -29,12 +29,14 @@ import moment from "moment";
 
 //Even though the above test was actually passing the test cases and getting back data from axios
 //we do not want to actually hit the API EVERY time we test.  This would cause additional API calls,
-//and could end up being a costly mistake.  ALso, we want to stay away from testing the actual api calls,
+//and could end up being a costly mistake.  Also, we want to stay away from testing the actual api calls,
 //for perforance reasons.  Uneccessary HTTP requests are usually public enemy number one when we are looking
 //for ways to optimize our application.
 
 //I will instead mock axios and test the async calls with a mocked version of axios...
 
+//We expect an array of rockets from our API call, below is a mock of what that return actually looks like
+//I am saving it to a constant for ease of reading
 const rockets = {
   rockets: [
     {
@@ -53,7 +55,10 @@ const rockets = {
   ]
 };
 
+//I want to also test getRockets() which was not in the original implentation.  We should test all our functions
+// as unit tests to catch any unforseen problems or side effects in our integrations.
 describe("getRockets()", () => {
+  //mocking the api call before every test runs
   beforeEach(() => {
     mockedAxios.get.mockImplementation(() =>
       Promise.resolve({
@@ -63,17 +68,53 @@ describe("getRockets()", () => {
   });
   describe("when an API call is made", () => {
     it("should render a list of rockets from the API call", async () => {
+      //liftoff!  do we get rockets back?
       const results = await getRockets();
       expect(results).toEqual(rockets);
     });
+    //no run away functions... testing if the function is called once to track down unecessary api calls
     it("function should have been called once", () => {
       expect(mockedAxios.get).toHaveBeenCalledTimes(1);
     });
+    //here I want to double check the api is being called with the right url
     it("function should have been called with the correct API endpoint ", () => {
       expect(mockedAxios.get).toHaveBeenCalledWith(
         "https://launchlibrary.net/1.4/rocket?mode=list"
       );
     });
+  });
+});
+
+describe("getRocketsList()", () => {
+  //here I simply copied the original test case and replaced the api response with the mocked version
+  // getRocketsList() calls getRockets() in its function body, now that we've separated that unit into
+  // its own test above, we can safely assert getRocketsList() is receiving the correct data.
+  beforeEach(() => {
+    mockedAxios.get.mockImplementation(() =>
+      Promise.resolve({
+        data: rockets
+      })
+    );
+  });
+  it("returns an array of Rockets", async () => {
+    const response = await getRocketsList();
+    if (response.data) {
+      expect(response.data.length).toEqual(1);
+      expect(response.data[0]).toEqual({
+        changed: moment("2017-02-21 00:00:00", "YYYY-MM-DD HH:mm:ss"),
+        configuration: "9 v1.1",
+        id: 1,
+        name: "Falcon 9 v1.1",
+        wikiURL: new URL("http://en.wikipedia.org/wiki/Falcon_9")
+      });
+    }
+  });
+  it("returns an error message on the catch", async () => {
+    try {
+      await getRocketsList();
+    } catch (e) {
+      expect(e).toMatch("error");
+    }
   });
 });
 

--- a/src/api/rockets/index.ts
+++ b/src/api/rockets/index.ts
@@ -68,6 +68,7 @@ export const getRocketsList = async () => {
     alert(
       "Our apologies, the data has errors, we'll try to request it one more time."
     );
-    return { errors: { message: error } };
+    //I'm changing this to return an array because our TYPE is expecting an array, easier to change this than rewrite all the type defs
+    return { errors: [{ message: error }] };
   }
 };

--- a/src/api/rockets/index.ts
+++ b/src/api/rockets/index.ts
@@ -33,13 +33,12 @@ export const parseUrl = (url: string | undefined) => {
     }
   } catch (e) {
     // Oh no!
-    console.log(e.message);
   }
   return result;
 };
 
 // Transform a JsonRocket to a Rocket
-const transformResponseRecord = (json: JsonRocket): Rocket => {
+export const transformResponseRecord = (json: JsonRocket): Rocket => {
   return {
     id: json.id,
     name: json.name,
@@ -49,14 +48,7 @@ const transformResponseRecord = (json: JsonRocket): Rocket => {
   };
 };
 
-// A sample response.
-// const FAKE_RESPONSE =
-//   '{"rockets":[{"id":1,"name":"Falcon 9 v1.1","configuration":"9 v1.1","defaultPads":"84,100","infoURL":null,"wikiURL":"http://en.wikipedia.org/wiki/Falcon_9","infoURLs":["http://www.spacex.com/falcon9"],"imageSizes":[320,480,640,720,768,800,960,1024,1080,1280],"imageURL":"https://s3.amazonaws.com/launchlibrary/RocketImages/Falcon9v1.1.jpg_1280.jpg","changed":"2017-02-21 00:00:00"},{"id":171,"name":"SS-520-5","configuration":"5","defaultPads":"","infoURL":"","wikiURL":"https://ja.wikipedia.org/wiki/SS-520%E3%83%AD%E3%82%B1%E3%83%83%E3%83%88","infoURLs":[""],"changed":"2017-02-21 00:00:00"},{"id":2,"name":"Atlas V 541","configuration":"541","infoURL":"","wikiURL":"http://en.wikipedia.org/wiki/Atlas_V","infoURLs":[""],"imageSizes":[320,480,640,720,768,800,960,1024,1080,1280,1440,1920],"imageURL":"https://s3.amazonaws.com/launchlibrary/RocketImages/Atlas+V+541_1920.jpg","changed":"2017-02-21 00:00:00"},{"id":3,"name":"Soyuz 2.1b","configuration":"2.1b","defaultPads":"","infoURL":"","wikiURL":"http://en.wikipedia.org/wiki/Soyuz-2_(rocket)","infoURLs":[""],"changed":"2017-02-21 00:00:00"}]}';
-
-// Simulate calling the API endpoint https://launchlibrary.net/1.4/rocket?mode=list
 export const getRockets = async () => {
-  //leaving this in for dramatic effect!
-  await new Promise(resolve => setTimeout(resolve, 500)); // Wait 0.5s for dramatic effect
   //saving my api call to a variable for ease of reading
   const url = "https://launchlibrary.net/1.4/rocket?mode=list";
   //Using the JsonResponse TYPE as generic for my axios call
@@ -68,13 +60,14 @@ export const getRockets = async () => {
 // Call the API endpoint and return the response body
 export const getRocketsList = async () => {
   try {
-    //I do not believe parsing an axios response is necessary so I removed it.
-    //Had to troubleshoot for a few minutes why data was not passing through, the culprit was the parse function.
     const data: JsonResponse = await getRockets();
     const apiRockets: JsonRocket[] = data.rockets;
     const rockets = apiRockets.map(record => transformResponseRecord(record));
     return { data: rockets };
   } catch (error) {
+    alert(
+      "Our apologies, the data has errors, we'll try to request it one more time."
+    );
     return { errors: { message: error } };
   }
 };

--- a/src/api/rockets/index.ts
+++ b/src/api/rockets/index.ts
@@ -33,6 +33,7 @@ export const parseUrl = (url: string | undefined) => {
     }
   } catch (e) {
     // Oh no!
+    console.log(e.message);
   }
   return result;
 };
@@ -54,18 +55,22 @@ const transformResponseRecord = (json: JsonRocket): Rocket => {
 
 // Simulate calling the API endpoint https://launchlibrary.net/1.4/rocket?mode=list
 export const getRockets = async () => {
+  //leaving this in for dramatic effect!
   await new Promise(resolve => setTimeout(resolve, 500)); // Wait 0.5s for dramatic effect
+  //saving my api call to a variable for ease of reading
   const url = "https://launchlibrary.net/1.4/rocket?mode=list";
+  //Using the JsonResponse TYPE as generic for my axios call
   const response = await axios.get<JsonResponse>(url);
-  console.log(response.data);
+  //axios returns a promise with a "data" field on the response, passing this to getRocketsList function
   return response.data;
 };
 
 // Call the API endpoint and return the response body
 export const getRocketsList = async () => {
   try {
+    //I do no believe parsing an axios response is necessary so I removed it.
+    //Had to troubleshoot for a few minutes why data was not passing through, the culprit was the parse function.
     const data: JsonResponse = await getRockets();
-    // console.log("test", data.rockets);
     const apiRockets: JsonRocket[] = data.rockets;
     const rockets = apiRockets.map(record => transformResponseRecord(record));
     return { data: rockets };

--- a/src/api/rockets/index.ts
+++ b/src/api/rockets/index.ts
@@ -68,7 +68,7 @@ export const getRockets = async () => {
 // Call the API endpoint and return the response body
 export const getRocketsList = async () => {
   try {
-    //I do no believe parsing an axios response is necessary so I removed it.
+    //I do not believe parsing an axios response is necessary so I removed it.
     //Had to troubleshoot for a few minutes why data was not passing through, the culprit was the parse function.
     const data: JsonResponse = await getRockets();
     const apiRockets: JsonRocket[] = data.rockets;

--- a/src/api/rockets/index.ts
+++ b/src/api/rockets/index.ts
@@ -1,5 +1,6 @@
 import { Rocket } from "../../store/rockets/types";
 import moment from "moment";
+import axios from "axios";
 
 /* This is the API adapter for Launch Library's rocket endpoint:
    https://launchlibrary.net/docs/1.4.1/api.html#rocket
@@ -48,19 +49,23 @@ const transformResponseRecord = (json: JsonRocket): Rocket => {
 };
 
 // A sample response.
-const FAKE_RESPONSE =
-  '{"rockets":[{"id":1,"name":"Falcon 9 v1.1","configuration":"9 v1.1","defaultPads":"84,100","infoURL":null,"wikiURL":"http://en.wikipedia.org/wiki/Falcon_9","infoURLs":["http://www.spacex.com/falcon9"],"imageSizes":[320,480,640,720,768,800,960,1024,1080,1280],"imageURL":"https://s3.amazonaws.com/launchlibrary/RocketImages/Falcon9v1.1.jpg_1280.jpg","changed":"2017-02-21 00:00:00"},{"id":171,"name":"SS-520-5","configuration":"5","defaultPads":"","infoURL":"","wikiURL":"https://ja.wikipedia.org/wiki/SS-520%E3%83%AD%E3%82%B1%E3%83%83%E3%83%88","infoURLs":[""],"changed":"2017-02-21 00:00:00"},{"id":2,"name":"Atlas V 541","configuration":"541","infoURL":"","wikiURL":"http://en.wikipedia.org/wiki/Atlas_V","infoURLs":[""],"imageSizes":[320,480,640,720,768,800,960,1024,1080,1280,1440,1920],"imageURL":"https://s3.amazonaws.com/launchlibrary/RocketImages/Atlas+V+541_1920.jpg","changed":"2017-02-21 00:00:00"},{"id":3,"name":"Soyuz 2.1b","configuration":"2.1b","defaultPads":"","infoURL":"","wikiURL":"http://en.wikipedia.org/wiki/Soyuz-2_(rocket)","infoURLs":[""],"changed":"2017-02-21 00:00:00"}]}';
+// const FAKE_RESPONSE =
+//   '{"rockets":[{"id":1,"name":"Falcon 9 v1.1","configuration":"9 v1.1","defaultPads":"84,100","infoURL":null,"wikiURL":"http://en.wikipedia.org/wiki/Falcon_9","infoURLs":["http://www.spacex.com/falcon9"],"imageSizes":[320,480,640,720,768,800,960,1024,1080,1280],"imageURL":"https://s3.amazonaws.com/launchlibrary/RocketImages/Falcon9v1.1.jpg_1280.jpg","changed":"2017-02-21 00:00:00"},{"id":171,"name":"SS-520-5","configuration":"5","defaultPads":"","infoURL":"","wikiURL":"https://ja.wikipedia.org/wiki/SS-520%E3%83%AD%E3%82%B1%E3%83%83%E3%83%88","infoURLs":[""],"changed":"2017-02-21 00:00:00"},{"id":2,"name":"Atlas V 541","configuration":"541","infoURL":"","wikiURL":"http://en.wikipedia.org/wiki/Atlas_V","infoURLs":[""],"imageSizes":[320,480,640,720,768,800,960,1024,1080,1280,1440,1920],"imageURL":"https://s3.amazonaws.com/launchlibrary/RocketImages/Atlas+V+541_1920.jpg","changed":"2017-02-21 00:00:00"},{"id":3,"name":"Soyuz 2.1b","configuration":"2.1b","defaultPads":"","infoURL":"","wikiURL":"http://en.wikipedia.org/wiki/Soyuz-2_(rocket)","infoURLs":[""],"changed":"2017-02-21 00:00:00"}]}';
 
 // Simulate calling the API endpoint https://launchlibrary.net/1.4/rocket?mode=list
 export const getRockets = async () => {
   await new Promise(resolve => setTimeout(resolve, 500)); // Wait 0.5s for dramatic effect
-  return FAKE_RESPONSE;
+  const url = "https://launchlibrary.net/1.4/rocket?mode=list";
+  const response = await axios.get<JsonResponse>(url);
+  console.log(response.data);
+  return response.data;
 };
 
 // Call the API endpoint and return the response body
 export const getRocketsList = async () => {
   try {
-    const data: JsonResponse = JSON.parse(await getRockets());
+    const data: JsonResponse = await getRockets();
+    // console.log("test", data.rockets);
     const apiRockets: JsonRocket[] = data.rockets;
     const rockets = apiRockets.map(record => transformResponseRecord(record));
     return { data: rockets };

--- a/src/components/rocketTable/RocketTable.test.tsx
+++ b/src/components/rocketTable/RocketTable.test.tsx
@@ -99,32 +99,29 @@ describe("RocketTable component", () => {
   });
 });
 
-//code below did not work --- tried triggering the alert component to render by mocking an error return,
-//but it looks like the Alert component is looking for an array, when the getRocketsList function returns
-//an object on its catch... this component will never render, even if I mock the error.  I tried a few things
-//that didn't work so well, and I didn't want to re-write everything before getting your opinion first!
+//decided to ahead and change around the error return in getRocketList to return an array
+//which allowed me to add to the reducer and correctly render the errors on the mock api calls
+//all is working now!
 
-//   describe("with errors", () => {
-//     it("displays the errors", async () => {
-//
-//       jest.spyOn(window, "alert").mockImplementation(() => {
-//         return {
-//           alert:
-//             "Our apologies, the data has errors, we'll try to request it one more time."
-//         };
-//       });
-//       //error message to be retunred by catch
-//       const newError = new Error("error");
-//       //mock error call
-//       mockedAxios.get.mockRejectedValue(newError);
-//       const store = configureStore();
-//       const container = render(
-//         <Provider store={store}>
-//           <RocketTable />
-//         </Provider>
-//       );
-//       const alerts = await container.findByTestId("alerts");
-//       expect(alerts).toHaveTextContent("error");
-//     });
-//   });
-// });
+describe("with errors", () => {
+  it("displays the errors", async () => {
+    jest.spyOn(window, "alert").mockImplementation(() => {
+      return {
+        alert:
+          "Our apologies, the data has errors, we'll try to request it one more time."
+      };
+    });
+    //error message to be retunred by catch
+    const newError = new Error("error");
+    //mock error call
+    mockedAxios.get.mockRejectedValue(newError);
+    const store = configureStore();
+    const container = render(
+      <Provider store={store}>
+        <RocketTable />
+      </Provider>
+    );
+    const alerts = await container.findByTestId("alerts");
+    expect(alerts).toHaveTextContent("error");
+  });
+});

--- a/src/components/rocketTable/RocketTable.test.tsx
+++ b/src/components/rocketTable/RocketTable.test.tsx
@@ -4,9 +4,36 @@ import { RocketTable } from "./";
 import { Provider } from "react-redux";
 import configureStore from "../../store/configureStore";
 import { UnconnectedRocketTable } from "./RocketTable";
+import axios from "axios";
+jest.mock("axios");
+const mockedAxios = axios as jest.Mocked<typeof axios>;
+
+//adding rocket axios mock to test react front end
+const rockets = {
+  rockets: [
+    {
+      id: 1,
+      name: "Falcon 9 v1.1",
+      configuration: "9 v1.1",
+      defaultPads: "84,100",
+      infoURL: null,
+      wikiURL: "http://en.wikipedia.org/wiki/Falcon_9",
+      infoURLs: ["http://www.spacex.com/falcon9"],
+      imageSizes: [320, 480, 640, 720, 768, 800, 960, 1024, 1080, 1280],
+      imageURL:
+        "https://s3.amazonaws.com/launchlibrary/RocketImages/Falcon9v1.1.jpg_1280.jpg",
+      changed: "2017-02-21 00:00:00"
+    }
+  ]
+};
 
 describe("RocketTable component", () => {
   jest.useFakeTimers();
+  mockedAxios.get.mockImplementation(() =>
+    Promise.resolve({
+      data: rockets
+    })
+  );
 
   describe("with a successful API call", () => {
     it("displays a table of rockets", async () => {
@@ -27,12 +54,18 @@ describe("RocketTable component", () => {
       const table = await findByTestId("rockets");
       const { getAllByRole } = within(table);
       expect(getAllByRole("columnheader")).toHaveLength(3);
-      expect(getAllByRole("row")).toHaveLength(31);
+
+      expect(getAllByRole("row")).toHaveLength(2);
     });
   });
 
   describe("with no results", () => {
     it("displays a message", async () => {
+      mockedAxios.get.mockImplementation(() =>
+        Promise.resolve({
+          data: []
+        })
+      );
       const { container } = render(
         <UnconnectedRocketTable loading={false} page={[]} errors={[]} />
       );
@@ -43,6 +76,12 @@ describe("RocketTable component", () => {
   describe("with errors", () => {
     it("displays the errors", async () => {
       const errors = [{ message: "Oh no!" }, { message: "Terrible!" }];
+      mockedAxios.get.mockImplementation(() =>
+        Promise.resolve({
+          data: errors
+        })
+      );
+
       const { findByTestId } = render(
         <UnconnectedRocketTable loading={false} page={[]} errors={errors} />
       );

--- a/src/components/rocketTable/RocketTable.test.tsx
+++ b/src/components/rocketTable/RocketTable.test.tsx
@@ -80,48 +80,30 @@ describe("RocketTable component", () => {
     });
   });
 
-  //leaving this in... see my notes below
+  //decided to ahead and change around the error return in getRocketList to return an array
+  //which allowed me to add to the reducer and correctly render the errors on the mock api calls
+  //all is working now!
+
   describe("with errors", () => {
     it("displays the errors", async () => {
-      const errors = [{ message: "Oh no!" }, { message: "Terrible!" }];
-      mockedAxios.get.mockImplementation(() =>
-        Promise.resolve({
-          data: errors
-        })
+      jest.spyOn(window, "alert").mockImplementation(() => {
+        return {
+          alert:
+            "Our apologies, the data has errors, we'll try to request it one more time."
+        };
+      });
+      //error message to be retunred by catch
+      const newError = new Error("error");
+      //mock error call
+      mockedAxios.get.mockRejectedValue(newError);
+      const store = configureStore();
+      const container = render(
+        <Provider store={store}>
+          <RocketTable />
+        </Provider>
       );
-
-      const { findByTestId } = render(
-        <UnconnectedRocketTable loading={false} page={[]} errors={errors} />
-      );
-      const alerts = await findByTestId("alerts");
-      expect(alerts).toHaveTextContent("Oh no!Terrible!");
+      const alerts = await container.findByTestId("alerts");
+      expect(alerts).toHaveTextContent("error");
     });
-  });
-});
-
-//decided to ahead and change around the error return in getRocketList to return an array
-//which allowed me to add to the reducer and correctly render the errors on the mock api calls
-//all is working now!
-
-describe("with errors", () => {
-  it("displays the errors", async () => {
-    jest.spyOn(window, "alert").mockImplementation(() => {
-      return {
-        alert:
-          "Our apologies, the data has errors, we'll try to request it one more time."
-      };
-    });
-    //error message to be retunred by catch
-    const newError = new Error("error");
-    //mock error call
-    mockedAxios.get.mockRejectedValue(newError);
-    const store = configureStore();
-    const container = render(
-      <Provider store={store}>
-        <RocketTable />
-      </Provider>
-    );
-    const alerts = await container.findByTestId("alerts");
-    expect(alerts).toHaveTextContent("error");
   });
 });

--- a/src/components/rocketTable/RocketTable.test.tsx
+++ b/src/components/rocketTable/RocketTable.test.tsx
@@ -27,7 +27,7 @@ describe("RocketTable component", () => {
       const table = await findByTestId("rockets");
       const { getAllByRole } = within(table);
       expect(getAllByRole("columnheader")).toHaveLength(3);
-      expect(getAllByRole("row")).toHaveLength(5);
+      expect(getAllByRole("row")).toHaveLength(31);
     });
   });
 

--- a/src/components/rocketTable/RocketTable.tsx
+++ b/src/components/rocketTable/RocketTable.tsx
@@ -17,7 +17,7 @@ const Alerts: FC<AlertsProps> = ({ errors }) => (
   <div data-testid="alerts">
     {errors.map((error, index) => (
       <Alert key={index} variant="warning">
-        {error.message}
+        {error.message.toString()}
       </Alert>
     ))}
   </div>

--- a/src/components/rocketTable/RocketTable.tsx
+++ b/src/components/rocketTable/RocketTable.tsx
@@ -9,6 +9,10 @@ import styled from "styled-components";
 import { ApiError } from "../../api/types";
 import { RocketRow } from ".";
 
+import { getRockets, getRocketsList } from "../../api/rockets/index";
+
+console.log(getRocketsList());
+
 interface AlertsProps {
   errors: ApiError[];
 }
@@ -43,6 +47,7 @@ export const UnconnectedRocketTable: FC<RocketsState> = ({
   if (errors.length > 0) {
     return <Alerts errors={errors} />;
   } else if (loading) {
+    console.log(page);
     return <Loading />;
   } else if (page.length === 0) {
     return <p>Sorry, no rockets found.</p>;

--- a/src/components/rocketTable/RocketTable.tsx
+++ b/src/components/rocketTable/RocketTable.tsx
@@ -43,7 +43,6 @@ export const UnconnectedRocketTable: FC<RocketsState> = ({
   if (errors.length > 0) {
     return <Alerts errors={errors} />;
   } else if (loading) {
-    console.log(page);
     return <Loading />;
   } else if (page.length === 0) {
     return <p>Sorry, no rockets found.</p>;

--- a/src/components/rocketTable/RocketTable.tsx
+++ b/src/components/rocketTable/RocketTable.tsx
@@ -9,10 +9,6 @@ import styled from "styled-components";
 import { ApiError } from "../../api/types";
 import { RocketRow } from ".";
 
-import { getRockets, getRocketsList } from "../../api/rockets/index";
-
-console.log(getRocketsList());
-
 interface AlertsProps {
   errors: ApiError[];
 }

--- a/src/components/rocketTable/RocketTable.tsx
+++ b/src/components/rocketTable/RocketTable.tsx
@@ -45,8 +45,9 @@ export const UnconnectedRocketTable: FC<RocketsState> = ({
   } else if (loading) {
     return <Loading />;
   } else if (page.length === 0) {
-    return <p>Sorry, no rockets found.</p>;
+    return <p data-testid="sorry">Sorry, no rockets found.</p>;
   }
+
   return (
     <Table striped bordered hover data-testid="rockets">
       <thead>

--- a/src/serviceWorker.ts
+++ b/src/serviceWorker.ts
@@ -11,9 +11,9 @@
 // opt-in, read https://bit.ly/CRA-PWA
 
 const isLocalhost = Boolean(
-  window.location.hostname === 'localhost' ||
+  window.location.hostname === "localhost" ||
     // [::1] is the IPv6 localhost address.
-    window.location.hostname === '[::1]' ||
+    window.location.hostname === "[::1]" ||
     // 127.0.0.0/8 are considered localhost for IPv4.
     window.location.hostname.match(
       /^127(?:\.(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)){3}$/
@@ -26,12 +26,9 @@ type Config = {
 };
 
 export function register(config?: Config) {
-  if (process.env.NODE_ENV === 'production' && 'serviceWorker' in navigator) {
+  if (process.env.NODE_ENV === "production" && "serviceWorker" in navigator) {
     // The URL constructor is available in all browsers that support SW.
-    const publicUrl = new URL(
-      process.env.PUBLIC_URL,
-      window.location.href
-    );
+    const publicUrl = new URL(process.env.PUBLIC_URL, window.location.href);
     if (publicUrl.origin !== window.location.origin) {
       // Our service worker won't work if PUBLIC_URL is on a different origin
       // from what our page is served on. This might happen if a CDN is used to
@@ -39,7 +36,7 @@ export function register(config?: Config) {
       return;
     }
 
-    window.addEventListener('load', () => {
+    window.addEventListener("load", () => {
       const swUrl = `${process.env.PUBLIC_URL}/service-worker.js`;
 
       if (isLocalhost) {
@@ -48,12 +45,7 @@ export function register(config?: Config) {
 
         // Add some additional logging to localhost, pointing developers to the
         // service worker/PWA documentation.
-        navigator.serviceWorker.ready.then(() => {
-          console.log(
-            'This web app is being served cache-first by a service ' +
-              'worker. To learn more, visit https://bit.ly/CRA-PWA'
-          );
-        });
+        navigator.serviceWorker.ready.then(() => {});
       } else {
         // Is not localhost. Just register service worker
         registerValidSW(swUrl, config);
@@ -72,15 +64,11 @@ function registerValidSW(swUrl: string, config?: Config) {
           return;
         }
         installingWorker.onstatechange = () => {
-          if (installingWorker.state === 'installed') {
+          if (installingWorker.state === "installed") {
             if (navigator.serviceWorker.controller) {
               // At this point, the updated precached content has been fetched,
               // but the previous service worker will still serve the older
               // content until all client tabs are closed.
-              console.log(
-                'New content is available and will be used when all ' +
-                  'tabs for this page are closed. See https://bit.ly/CRA-PWA.'
-              );
 
               // Execute callback
               if (config && config.onUpdate) {
@@ -90,7 +78,6 @@ function registerValidSW(swUrl: string, config?: Config) {
               // At this point, everything has been precached.
               // It's the perfect time to display a
               // "Content is cached for offline use." message.
-              console.log('Content is cached for offline use.');
 
               // Execute callback
               if (config && config.onSuccess) {
@@ -102,21 +89,21 @@ function registerValidSW(swUrl: string, config?: Config) {
       };
     })
     .catch(error => {
-      console.error('Error during service worker registration:', error);
+      console.error("Error during service worker registration:", error);
     });
 }
 
 function checkValidServiceWorker(swUrl: string, config?: Config) {
   // Check if the service worker can be found. If it can't reload the page.
   fetch(swUrl, {
-    headers: { 'Service-Worker': 'script' }
+    headers: { "Service-Worker": "script" }
   })
     .then(response => {
       // Ensure service worker exists, and that we really are getting a JS file.
-      const contentType = response.headers.get('content-type');
+      const contentType = response.headers.get("content-type");
       if (
         response.status === 404 ||
-        (contentType != null && contentType.indexOf('javascript') === -1)
+        (contentType != null && contentType.indexOf("javascript") === -1)
       ) {
         // No service worker found. Probably a different app. Reload the page.
         navigator.serviceWorker.ready.then(registration => {
@@ -130,14 +117,12 @@ function checkValidServiceWorker(swUrl: string, config?: Config) {
       }
     })
     .catch(() => {
-      console.log(
-        'No internet connection found. App is running in offline mode.'
-      );
+      //error
     });
 }
 
 export function unregister() {
-  if ('serviceWorker' in navigator) {
+  if ("serviceWorker" in navigator) {
     navigator.serviceWorker.ready
       .then(registration => {
         registration.unregister();

--- a/src/setupTests.ts
+++ b/src/setupTests.ts
@@ -2,4 +2,4 @@
 // allows you to do things like:
 // expect(element).toHaveTextContent(/react/i)
 // learn more: https://github.com/testing-library/jest-dom
-import '@testing-library/jest-dom/extend-expect';
+import "@testing-library/jest-dom/extend-expect";

--- a/src/store/rockets/actions.test.ts
+++ b/src/store/rockets/actions.test.ts
@@ -1,0 +1,52 @@
+import { error, listRequest, listSuccess } from "./actions";
+import { parseUrl } from "../../api/rockets/index";
+import moment from "moment";
+
+import { ActionTypes } from "./types";
+
+//creating mock pyaloads for my action creators
+const rocketPayload = {
+  page: [
+    {
+      id: 1,
+      name: "Falcon 9 v1.1",
+      configuration: "9 v1.1",
+      wikiURL: parseUrl("http://en.wikipedia.org/wiki/Falcon_9"),
+      changed: moment("2017-02-21 00:00:00", "YYYY-MM-DD HH:mm:ss")
+    }
+  ]
+};
+
+const errorPayload = [{ message: "error" }];
+
+//testing all action creators with expected results from the mocks
+describe("actions", () => {
+  describe("listRequest()", () => {
+    it("should create an action to grab the list of items", () => {
+      const expectedAction = {
+        type: ActionTypes.LIST_REQUEST
+      };
+      expect(listRequest()).toEqual(expectedAction);
+    });
+  });
+
+  describe("listSuccess()", () => {
+    it("should create an action to grab the list of items", () => {
+      const expectedAction = {
+        type: ActionTypes.LIST_SUCCESS,
+        payload: rocketPayload
+      };
+      expect(listSuccess(rocketPayload)).toEqual(expectedAction);
+    });
+  });
+
+  describe("error", () => {
+    it("should return a payload of errors", () => {
+      const expectedAction = {
+        type: ActionTypes.ERROR,
+        payload: errorPayload
+      };
+      expect(error(errorPayload)).toEqual(expectedAction);
+    });
+  });
+});

--- a/src/store/rockets/reducer.ts
+++ b/src/store/rockets/reducer.ts
@@ -25,4 +25,12 @@ export const rocketsReducer = createReducer<RocketsState, RocketAction>(
       loading: false,
       page: action.payload.page
     };
+  })
+  //this was missing, added it so it correctly renders errors on our frontend
+  .handleAction(actions.error, (state, action) => {
+    return {
+      ...state,
+      loading: false,
+      errors: action.payload
+    };
   });

--- a/src/store/rockets/sagas.test.ts
+++ b/src/store/rockets/sagas.test.ts
@@ -8,7 +8,7 @@ jest.mock("axios");
 const mockedAxios = axios as jest.Mocked<typeof axios>;
 
 //please excuse my naive approach to testing sagas... I'm relatively new to sagas having worked mainly in Thunks for the last 3 years
-//I gave it my bets show and I'm covering 100%... I'm sure I'm missing some things.
+//I gave it my best shot and I'm covering 100%... I'm sure I'm missing some things.
 
 //mocks for axios
 

--- a/src/store/rockets/sagas.test.ts
+++ b/src/store/rockets/sagas.test.ts
@@ -48,7 +48,7 @@ const newError = new TypeError("Cannot read property 'map' of undefined");
 
 //error payload for mox axios call
 const errorPayload = {
-  message: newError
+  error: [{ message: newError }]
 };
 
 //testing handle request saga
@@ -84,7 +84,7 @@ describe("handleListRequest", () => {
     const response = await getRocketsList();
     gen.next();
     expect(gen.next(response).value).toEqual(
-      put({ type: ActionTypes.ERROR, payload: errorPayload })
+      put({ type: ActionTypes.ERROR, payload: errorPayload.error })
     );
     expect(gen.next().done).toBeTruthy();
   });

--- a/src/store/rockets/sagas.test.ts
+++ b/src/store/rockets/sagas.test.ts
@@ -1,0 +1,91 @@
+import { handleListRequest } from "./sagas";
+import { put } from "redux-saga/effects";
+import { ActionTypes } from "./types";
+import { getRocketsList, parseUrl } from "../../api/rockets/index";
+import moment from "moment";
+import axios from "axios";
+jest.mock("axios");
+const mockedAxios = axios as jest.Mocked<typeof axios>;
+
+//please excuse my naive approach to testing sagas... I'm relatively new to sagas having worked mainly in Thunks for the last 3 years
+//I gave it my bets show and I'm covering 100%... I'm sure I'm missing some things.
+
+//mocks for axios
+
+const rockets = {
+  rockets: [
+    {
+      id: 1,
+      name: "Falcon 9 v1.1",
+      configuration: "9 v1.1",
+      defaultPads: "84,100",
+      infoURL: null,
+      wikiURL: "http://en.wikipedia.org/wiki/Falcon_9",
+      infoURLs: ["http://www.spacex.com/falcon9"],
+      imageSizes: [320, 480, 640, 720, 768, 800, 960, 1024, 1080, 1280],
+      imageURL:
+        "https://s3.amazonaws.com/launchlibrary/RocketImages/Falcon9v1.1.jpg_1280.jpg",
+      changed: "2017-02-21 00:00:00"
+    }
+  ]
+};
+
+//rocket payload to test saga return
+const rocketPayload = {
+  page: [
+    {
+      id: 1,
+      name: "Falcon 9 v1.1",
+      configuration: "9 v1.1",
+      wikiURL: parseUrl("http://en.wikipedia.org/wiki/Falcon_9"),
+      changed: moment("2017-02-21 00:00:00", "YYYY-MM-DD HH:mm:ss")
+    }
+  ]
+};
+
+//error to throw when payload is wrong
+const newError = new TypeError("Cannot read property 'map' of undefined");
+
+//error payload for mox axios call
+const errorPayload = {
+  message: newError
+};
+
+//testing handle request saga
+describe("handleListRequest", () => {
+  it("should match the payload ", async () => {
+    mockedAxios.get.mockImplementation(() =>
+      Promise.resolve({
+        data: rockets
+      })
+    );
+    const gen = handleListRequest();
+    const response = await getRocketsList();
+    gen.next();
+    expect(gen.next(response).value).toEqual(
+      put({ type: ActionTypes.LIST_SUCCESS, payload: rocketPayload })
+    );
+    expect(gen.next().done).toBeTruthy();
+  });
+  it("should list errors in response", async () => {
+    mockedAxios.get.mockImplementation(() =>
+      Promise.resolve({
+        data: errorPayload
+      })
+    );
+    jest.spyOn(window, "alert").mockImplementation(() => {
+      return {
+        alert:
+          "Our apologies, the data has errors, we'll try to request it one more time."
+      };
+    });
+
+    const gen = handleListRequest();
+    const response = await getRocketsList();
+    gen.next();
+    expect(gen.next(response).value).toEqual(
+      put({ type: ActionTypes.ERROR, payload: errorPayload })
+    );
+    expect(gen.next().done).toBeTruthy();
+  });
+});

--- a/src/store/rockets/sagas.ts
+++ b/src/store/rockets/sagas.ts
@@ -4,7 +4,7 @@ import { listSuccess, error, listRequest } from "./actions";
 import { getRocketsList } from "../../api/rockets";
 
 // Calls the API endpoint to get a page of rockets whenever a LIST_REQUEST action is dispatched
-function* handleListRequest() {
+export function* handleListRequest() {
   const response = yield call(getRocketsList);
 
   if ("errors" in response) {
@@ -15,13 +15,13 @@ function* handleListRequest() {
 }
 
 // Watches for a list request action
-function* watchListRequest() {
+export function* watchListRequest() {
   yield takeLatest(ActionTypes.LIST_REQUEST, handleListRequest);
 }
 
 /* If this was a real app with a router like "connected-react-router", we'd watch
    for the appropriate location change action to trigger the list request action. */
-function* initialSaga() {
+export function* initialSaga() {
   yield put(listRequest());
 }
 


### PR DESCRIPTION
- Got the test runner working, I apologize for not having that set correctly.
- Test runner showing 100% coverage
- removed unnecessary comments and console.logs
- mocked api in src/components/rocketTable/RocketTable.test.tsx -- No longer making outside calls.
- removed the dramatic setTimeout function on the getRockets function
- Added a window.alert error in getRocketsList in the event API service returns an error.  This
  alert would give the user some feedback as to the API being down. 
- Sagas tested - new to sagas (have always used thunks), so this took some time, so excuse my naive approach.
- Actions tested.

